### PR TITLE
Fix typo in deploy script

### DIFF
--- a/travis_deploy.sh
+++ b/travis_deploy.sh
@@ -17,7 +17,7 @@ then
 fi
 
 # if this is on the develop branch and this is not a PR, deploy it
-if [ $BRANCH = "develop" # -a $PR = "false" ]
+if [ $BRANCH = "develop" -a $PR = "false" ]
 then
     aws ecr get-login --region=us-east-1 | bash
     docker tag -f rapidpro_rapidpro:latest 387526361725.dkr.ecr.us-east-1.amazonaws.com/rapidpro:$TAG


### PR DESCRIPTION
There was a syntax error (an extra `#` left over from debug) that was
causing the deploy script to fail. This commit removes it
